### PR TITLE
add space at end of Hello React string for consistancy with Hello JS …

### DIFF
--- a/demo/script.js
+++ b/demo/script.js
@@ -14,7 +14,7 @@ const render = () => {
     React.createElement(
       "div",
       { className: "demo" },
-      "Hello React",
+      "Hello React ",
       React.createElement("input"),
       React.createElement(
         "p",


### PR DESCRIPTION
Super tiny fix. When viewing index.html I noticed there was no space before the input box after the "Hello React" so that it is consistent with the "Hello JS" formatting. Small potatoes!